### PR TITLE
feat: Add functionality to set initial directory for image selection

### DIFF
--- a/sd_prompt_reader/app.py
+++ b/sd_prompt_reader/app.py
@@ -671,11 +671,13 @@ class App(Tk):
                     case SortMode.DES:
                         textbox.sort_des()
 
-    @staticmethod
-    def select_image():
+    def select_image(self):
+        initialdir = "/"
+        if self.file_path:
+            initialdir = self.file_path.parent
         return filedialog.askopenfilename(
             title='Select your image file',
-            initialdir="/",
+            initialdir=initialdir,
             filetypes=(("image files", "*.png *.jpg *jpeg *.webp"),)
         )
 


### PR DESCRIPTION
This commit adds functionality to set the initial directory for image selection in the select_image method of the App class in app.py. The initial directory is determined based on the self.file_path attribute. If self.file_path is set, the initial directory is set to its parent directory; otherwise, the initial directory is set to the root directory ("/"). This enhancement allows users to conveniently browse for image files in a familiar directory.